### PR TITLE
Update GitHub profile with current work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,79 @@
+# Hi, I'm Chris Nesbitt-Smith 👋
 
+**Forward-Thinking Technology Leader** | London, UK 🪂
+
+I'm a technology strategist who helps organizations navigate complex technical transformations. From advising government on digital infrastructure to building secure, scalable systems for critical national infrastructure, I focus on solving real problems with pragmatic, forward-looking solutions.
+
+## What I Do
+
+I work at the intersection of **policy, security, and modern infrastructure**, helping organizations adopt emerging technologies responsibly and at scale.
+
+Currently, I advise the UK Government on cloud enablement and digital transformation, including leading architectural direction for the [National Digital Exchange](https://co-cddo.github.io/ndx/) — a platform designed to break down silos and accelerate technology adoption across the public sector.
+
+I provide strategic consulting and hands-on training to:
+- UK & US Government departments
+- Multinational enterprises
+- Large charities and NGOs
+
+### Core Focus Areas
+
+- **Policy as versioned code** — bringing software engineering practices to governance and compliance
+- **Security-first architecture** — container security, supply chain integrity, admission control patterns
+- **Cloud-native transformation** — multi-cloud strategy, modernization roadmaps, and platform engineering
+- **DevSecOps culture** — embedding security throughout the development lifecycle
+- **Open source strategy** — building in the open, community-driven development
+
+## Philosophy
+
+I believe the best technology solutions come from:
+- **Developer empowerment** — giving teams the tools and autonomy to move fast safely
+- **Security by design** — not as an afterthought, but foundational to every decision
+- **Open standards** — avoiding vendor lock-in and building for longevity
+- **Privacy-first thinking** — especially in consumer-facing systems
+- **Continuous learning** — staying ahead of the curve while staying grounded in fundamentals
+
+## Speaking & Community
+
+I regularly speak at international conferences on cloud-native technologies, security, platform engineering, and digital transformation:
+
+- **DevSecCon** — Policy as [versioned] code, modern security patterns
+- **Open Source Summit** — Cloud-native governance and compliance
+- **Global Government Forum** — Digital transformation in government
+- **KubeCon / CloudNativeCon** — Container security and platform architecture
+
+You can find my talks and presentations at [talks.cns.me](https://talks.cns.me).
+
+## Featured Work
+
+### [cosign-keyless-admission-webhook](https://github.com/appvia/cosign-keyless-admission-webhook)
+Built the first admission controller using cosign to verify container image signatures — ensuring only cryptographically signed and verified images run in production clusters.
+
+### [k8s-opa-boilerplate](https://github.com/chrisns/k8s-opa-boilerplate)
+Practical implementation of policy as versioned code using Open Policy Agent (OPA) and kustomize. A real-world example of treating compliance as code.
+
+### [home-automation-roadmap](https://github.com/chrisns/home-automation-roadmap)
+My approach to building privacy-focused, open-source home automation systems. Because your smart home shouldn't phone home to Big Tech.
+
+### [devpsyops](https://devpsyops.com)
+Exploring the intersection of psychology and technical operations — because understanding human behavior is as important as understanding systems.
+
+## Beyond Tech
+
+When I'm not thinking about infrastructure and security, I'm probably in the sky. I've completed over 150 skydives and regularly indoor skydive. The parallels between skydiving and technology? Both require careful planning, risk management, and the confidence to take calculated leaps. 🪂
+
+## Let's Connect
+
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white)](https://uk.linkedin.com/in/cnesbittsmith)
+[![Website](https://img.shields.io/badge/website-000000?style=for-the-badge&logo=About.me&logoColor=white)](https://cns.me)
+[![Speaker Profile](https://img.shields.io/badge/Speaker-FF6B6B?style=for-the-badge&logo=sessionize&logoColor=white)](https://sessionize.com/cns)
+[![Talks](https://img.shields.io/badge/Talks-4285F4?style=for-the-badge&logo=googlepresentations&logoColor=white)](https://talks.cns.me)
+
+---
+
+![GitHub Stats](https://github-readme-stats.vercel.app/api?username=chrisns&show_icons=true&theme=default&hide_title=true&count_private=false&include_all_commits=true)
+
+---
+
+**📫 Open to:** Strategic consulting, speaking opportunities, and collaboration on open source projects that push the boundaries of what's possible.
+
+_Views and opinions expressed here are my own and do not represent those of my employers or clients._


### PR DESCRIPTION
- Position as technology strategist and leader, not just Kubernetes expert
- Broaden focus to policy, security, and modern infrastructure
- Add Philosophy section to showcase values and approach
- Reduce specific technology references in favor of strategic framing
- Maintain technical credibility while avoiding pigeonholing
- Enhance skydiving analogy with leadership parallel